### PR TITLE
test: use 'env python3'

### DIFF
--- a/tests/native-messaging-hosts/write-on-close.py
+++ b/tests/native-messaging-hosts/write-on-close.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 from pathlib import Path


### PR DESCRIPTION
'env python' only works on some RH derivatives, on Debian and derivatives it does not work by default.

Fixes https://github.com/flatpak/xdg-native-messaging-proxy/issues/10